### PR TITLE
Fix bitwise operation in PostMW

### DIFF
--- a/sp1.ahk
+++ b/sp1.ahk
@@ -199,10 +199,9 @@ return
 
 PostMW(hWnd, delta, modifiers, x, y) {
     CoordMode, Mouse, Screen
-    LOX := x & 0xFFFF
-    HOY := y & 0xFFFF
-
-    PostMessage, 0x20A, delta << 16 | modifiers, HOY << 16 | LOX ,, A
+    lowOrderX := x & 0xFFFF
+    highOrderY := y & 0xFFFF
+    PostMessage, 0x20A, delta << 16 | modifiers, highOrderY << 16 | lowOrderX ,, A
 }
 
 Timer:

--- a/sp1.ahk
+++ b/sp1.ahk
@@ -199,7 +199,10 @@ return
 
 PostMW(hWnd, delta, modifiers, x, y) {
     CoordMode, Mouse, Screen
-    PostMessage, 0x20A, delta << 16 | modifiers, y << 16 | x ,, A
+    LOX := x & 0xFFFF
+    HOY := y & 0xFFFF
+
+    PostMessage, 0x20A, delta << 16 | modifiers, HOY << 16 | LOX ,, A
 }
 
 Timer:


### PR DESCRIPTION
The bitwise or could lead to the wrong result if the mouse coordinates are negative. By forcing the values to their 16 bit equivalent, the or operation works as intended.

This should fix #4